### PR TITLE
Apply strict mode to allow use of "let" operator

### DIFF
--- a/lib/passport-google-id-token/strategy.js
+++ b/lib/passport-google-id-token/strategy.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Module dependencies.
  */


### PR DESCRIPTION
Not having this gives a syntax error: "Block scoped declarations.... not yet supported outside strict mode"